### PR TITLE
Set the background of the popup. Used standard border colours (followed style guides)

### DIFF
--- a/styles/git-time-machine.less
+++ b/styles/git-time-machine.less
@@ -43,19 +43,22 @@
     width: 5px;
     top: 0px;
     right: 10px;
-    background-color: rgba(0, 128, 0, 0.29);
+    background-color: @pane-item-border-color;
   }
 
 }
 
 .git-timemachine-popup {
+  background: @base-background-color;
+  color: @text-color;
+
   &.popover-list {
     position: absolute;
     z-index: 10;
     width: 400px;
     max-height: 300px;
     overflow-y: auto;
-    border: solid 4px rgba(0, 128, 0, 0.29);
+    border: solid 4px @pane-item-border-color;
   }
 
   .controls {


### PR DESCRIPTION
Hi!

First of all, thanks for a great job! I just want to present a fix for a small UI issue:

<img width="1280" alt="screen shot 2016-01-29 at 10 30 36 pm" src="https://cloud.githubusercontent.com/assets/1846484/12688769/a6f9f736-c6d8-11e5-8c6f-e645b6ddfae9.png">

As you can see, the problem is that the background is absent. Also, it seems that using "default" variables for colours might provide better UX despite user's theme.