### PR TITLE
Fixed error on older git versions.

### DIFF
--- a/lib/git-revision-view.coffee
+++ b/lib/git-revision-view.coffee
@@ -49,8 +49,6 @@ class GitRevisionView
 
   @_loadRevision: (file, hash, stdout, exit) ->
     showArgs = [
-      "-C",
-      path.dirname(file),
       "show",
       "#{hash}:./#{path.basename(file)}"
     ]
@@ -58,8 +56,9 @@ class GitRevisionView
     new BufferedProcess {
       command: "git",
       args: showArgs,
+      options: { cwd:path.dirname(file) },
       stdout,
-      exit 
+      exit
     }
 
 


### PR DESCRIPTION
Removed usage of git argument `-C` which is not available on all git versions (eg: 1.8.3.1).
The path is instead passed via Atom's BufferedProcess constructor options.

On my computer clicking on the timeline would not work as git exited with error code 129. After I understood the problem was, the fix seemed easy enough not to warrant the creation of an issue. That said, I have only tested this on my personal machine:
- CentOS7
- git 1.8.3.1
- Atom 1.6.0 and 1.7.0-beta0