### PR TITLE
Load Git file data only when timeline is visible

### DIFF
--- a/lib/git-time-machine-view.coffee
+++ b/lib/git-time-machine-view.coffee
@@ -18,6 +18,7 @@ class GitTimeMachineView
 
 
   setEditor: (editor) ->
+    return unless editor != @editor
     file = editor?.getPath()
     return unless file? && !str.startsWith(path.basename(file), GitRevisionView.FILE_PREFIX)
     [@editor, @file] = [editor, file]
@@ -57,8 +58,8 @@ class GitTimeMachineView
 
   getElement: ->
     return @$element.get(0)
-  
-  
+
+
   gitCommitHistory: (file=@file)->
     return null unless file?
     try
@@ -72,12 +73,12 @@ class GitTimeMachineView
       return null
 
     return commits;
-      
+
   _renderPlaceholder: () ->
     @$element.html("<div class='placeholder'>Select a file in the git repo to see timeline</div>")
     return
-    
-    
+
+
   _renderCloseHandle: () ->
     $closeHandle = $("<div class='close-handle'>X</div>")
     @$element.append $closeHandle
@@ -87,13 +88,13 @@ class GitTimeMachineView
       e.stopPropagation()
       # why not? instead of adding callback, our own event...
       atom.commands.dispatch(atom.views.getView(atom.workspace), "git-time-machine:toggle")
-      
-    
+
+
 
   _renderTimeline: (commits) ->
     @timeplot ||= new GitTimeplot(@$element)
     @timeplot.render(@editor, commits)
-    return 
+    return
 
 
   _renderStats: (commits) ->

--- a/lib/git-time-machine.coffee
+++ b/lib/git-time-machine.coffee
@@ -41,5 +41,6 @@ module.exports = GitTimeMachine =
 
   _onDidChangeActivePaneItem: (editor) ->
     editor = atom.workspace.getActiveTextEditor()
-    @gitTimeMachineView.setEditor(editor)
+    if @timelinePanel.isVisible()
+      @gitTimeMachineView.setEditor(editor)
     return


### PR DESCRIPTION
This makes viewing and switching between files quicker when the
timeline is not visible. The only small downside would be that the
loading would happen when the timeline is toggled, rather than before
that. I think that this trade-off is optimal though. Merging this commit
to master would resolve #41.

This commit also makes a small change to only re-render the view if the
new active editor is not the same as the current active editor, slightly
optimizing performance when switching between the diff panes.