### PR TITLE
Upgrade split-diff package, fix blob render error

### DIFF
--- a/lib/git-timeplot.coffee
+++ b/lib/git-timeplot.coffee
@@ -26,11 +26,11 @@ module.exports = class GitTimeplot
     #  nothing to do here
 
 
-  # @commitData - array of javascript objects like those returned by GitUtils.getFileCommitHistory 
+  # @commitData - array of javascript objects like those returned by GitUtils.getFileCommitHistory
   #               should be in reverse chron order
   render: (@editor, @commitData) ->
     @popup?.remove()
-    
+
     @file = @editor.getPath()
 
     @$timeplot = @$element.find('.timeplot')
@@ -97,7 +97,7 @@ module.exports = class GitTimeplot
     .attr("cy", (d)=> @y(moment.unix(d.authorDate).hour()))
     .transition()
     .duration(500)
-    .attr("r", (d) -> r(d.linesAdded + d.linesDeleted))
+    .attr("r", (d) -> r(d.linesAdded + d.linesDeleted || 0))
 
 
   # hover marker is the green vertical line that follows the mouse on the timeplot
@@ -138,14 +138,14 @@ module.exports = class GitTimeplot
     # debouncing gives a little time to get the mouse into the popup
     @_debouncedHidePopup();
     @isMouseDown = false
-    
-    
+
+
   _onMousedown: (evt) ->
     @isMouseDown = true
     @_hidePopup(force: true)
     @_debouncedViewNearestRevision()
 
-  
+
   _onMouseup: (evt) ->
     @isMouseDown = false
 
@@ -180,7 +180,7 @@ module.exports = class GitTimeplot
   _hidePopup: (options={}) ->
     options = _.defaults options,
       force: false
-    
+
     return if !options.force && (@popup?.isMouseInPopup() || @isMouseInElement)
     @popup?.hide().remove()
 
@@ -194,7 +194,7 @@ module.exports = class GitTimeplot
     commits = _.filter @commitData, (c) -> moment.unix(c.authorDate).isBetween(tStart, tEnd)
     # console.log("gtm: inspecting #{commits.length} commits betwee #{tStart.toString()} - #{tEnd.toString()}")
     return [commits, tStart, tEnd];
-    
+
   # return the nearest commit to hover marker or previous
   _getNearestCommit: () ->
     [filteredCommitData, tStart, tEnd] = @_filterCommitData()
@@ -208,6 +208,3 @@ module.exports = class GitTimeplot
     nearestCommit =  @_getNearestCommit()
     if nearestCommit?
       RevisionView.showRevision(@editor, nearestCommit.hash)
-
-
-

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "d3": "^3.5.6",
     "moment": "^2.10.6",
     "underscore-plus": "1.x",
-    "split-diff": "git+https://github.com/mupchrch/split-diff.git#v0.5.2",
+    "split-diff": "git+https://github.com/mupchrch/split-diff.git#v0.6.3",
     "git-log-utils": "0.2.1"
   },
   "devDependencies": {}


### PR DESCRIPTION
The split-diff package has several new features since the current
version (0.5.2), namely highlighting word changes within a line,
gutter line number highlighting, and several bug fixes. Package settings
for split-diff have to be manually set because the package is never
actually being activated. I also removed the manual scroll syncing
because I didn't see a problem with it in the new version. I could just
be missing it...

On another note, when there is no "linesAdded" or "linesRemoved"
properties in the git data, an error is thrown in the console. I made a
small change to use 0 in that case (because `undefined` + `undefined` ==
`NaN`...d3 throws an error for that). This would fix issue #42.