### PR TITLE
Fix deprecation notice in package's entry point

### DIFF
--- a/lib/git-time-machine.coffee
+++ b/lib/git-time-machine.coffee
@@ -1,5 +1,5 @@
 GitTimeMachineView = require './git-time-machine-view'
-{TextEditor, CompositeDisposable} = require 'atom'
+{CompositeDisposable} = require 'atom'
 
 module.exports = GitTimeMachine =
   gitTimeMachineView: null


### PR DESCRIPTION
This commit resolves a deprecation warning raised by including the `TextEditor` class, which is no longer a public interface.