### PR TITLE
Update split diff dependency to v0.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "d3": "^3.5.6",
     "git-log-utils": "0.2.2",
     "moment": "^2.10.6",
-    "split-diff": "git+https://github.com/mupchrch/split-diff.git#v0.7.5",
+    "split-diff": "git+https://github.com/mupchrch/split-diff.git#v0.8.3",
     "underscore-plus": "1.x"
   },
   "devDependencies": {}


### PR DESCRIPTION
Updating the split-diff dependency to v0.8.3 will fix #60.

No other changes necessary, since I have not added any functionality/settings that would need to be reflected in your code.