### PR TITLE
Add a more reader-friendly label for menu entry

### DIFF
--- a/menus/git-time-machine.cson
+++ b/menus/git-time-machine.cson
@@ -10,7 +10,7 @@
   {
     'label': 'Packages'
     'submenu': [
-      'label': 'git-time-machine'
+      'label': 'Git Time Machine'
       'submenu': [
         {
           'label': 'Toggle for current file'


### PR DESCRIPTION
This looks rather jarring...

<img src="https://cloud.githubusercontent.com/assets/2346707/15768833/191b5946-2998-11e6-8c8d-72544fed6392.png" width="384" valign="bottom" alt="Figure 1" />

I've amended this package's label (and [that of the other](https://github.com/alexcorre/git-blame/pull/138)) so it integrates better with every other package's menu-label:

<img src="https://cloud.githubusercontent.com/assets/2346707/15768869/82cb2f74-2998-11e6-93dc-da1e168d4df8.png" width="384" valign="bottom" alt="Figure 2" />