### PR TITLE
fix split-diff url

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "d3": "^3.5.6",
     "git-log-utils": "0.2.2",
     "moment": "^2.10.6",
-    "split-diff": "git+https://github.com/mupchrch/split-diff.git#v0.8.3",
+    "split-diff": "https://github.com/mupchrch/split-diff/archive/v0.8.3.tar.gz",
     "underscore-plus": "1.x"
   },
   "devDependencies": {}


### PR DESCRIPTION
In Windows 10 and OS X apm can't install split-diff from github using tags. Replaced with direct link. 
