### PR TITLE
Conditionally check for Split-Diff configuration

### DIFF
--- a/lib/git-revision-view.coffee
+++ b/lib/git-revision-view.coffee
@@ -137,11 +137,11 @@ class GitRevisionView
       editor1: newTextEditor    # the older revision
       editor2: editor           # current rev
 
-    SplitDiff._setConfig 'rightEditorColor', 'green'
-    SplitDiff._setConfig 'leftEditorColor', 'red'
-    SplitDiff._setConfig 'diffWords', true
-    SplitDiff._setConfig 'ignoreWhitespace', true
-    SplitDiff._setConfig 'scrollSyncType', 'Vertical + Horizontal'
+    if not SplitDiff._getConfig 'rightEditorColor' then SplitDiff._setConfig 'rightEditorColor', 'green'
+    if not SplitDiff._getConfig 'leftEditorColor' then SplitDiff._setConfig 'leftEditorColor', 'red'
+    if not SplitDiff._getConfig 'diffWords' then SplitDiff._setConfig 'diffWords', true
+    if not SplitDiff._getConfig 'ignoreWhitespace' then SplitDiff._setConfig 'ignoreWhitespace', true
+    if not SplitDiff._getConfig 'scrollSyncType' then SplitDiff._setConfig 'scrollSyncType', 'Vertical + Horizontal'
     
     SplitDiff.editorSubscriptions = new CompositeDisposable()
     SplitDiff.editorSubscriptions.add editors.editor1.onDidStopChanging =>


### PR DESCRIPTION
This fixes config overwrites for https://github.com/littlebee/git-time-machine/issues/97 

Conditionally check to see if Split-Diff has previously been configured. If so, leave that configuration in place, otherwise set the configuration