### PR TITLE
Update package.json Split-Diff url

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "d3": "3.5.6",
     "git-log-utils": "0.2.3",
     "moment": "2.10.6",
-    "split-diff": "https://github.com/mupchrch/split-diff/archive/v1.1.1.tar.gz",
+    "split-diff": "git://github.com/mupchrch/split-diff.git",
     "underscore-plus": "1.x"
   },
   "devDependencies": {}


### PR DESCRIPTION
Use `git://` url for Split-Diff to always get the latest version of Split-Diff