### PR TITLE
Use split-diff service API

### DIFF
--- a/lib/git-revision-view.coffee
+++ b/lib/git-revision-view.coffee
@@ -59,18 +59,6 @@ class GitRevisionView
     }
 
 
-  @_getInitialLineNumber: (editor) ->
-    editorEle = atom.views.getView editor
-    lineNumber = 0
-    if editor? && editor != ''
-      lineNumber = editorEle.getLastVisibleScreenRow()
-      # console.log "_getInitialLineNumber", lineNumber
-
-      # TODO: why -5?  this is what it took to actually sync the last line number
-      #    between two editors
-      return lineNumber - 5
-
-
   @_showRevision: (file, editor, revHash, fileContents, options={}) ->
     outputDir = "#{atom.getConfigDirPath()}/git-time-machine"
     fs.mkdir outputDir if not fs.existsSync outputDir

--- a/lib/git-revision-view.coffee
+++ b/lib/git-revision-view.coffee
@@ -5,8 +5,6 @@ fs = require 'fs'
 {CompositeDisposable, BufferedProcess} = require "atom"
 {$} = require "atom-space-pen-views"
 
-SplitDiff = require 'split-diff'
-
 
 module.exports =
 class GitRevisionView
@@ -30,7 +28,7 @@ class GitRevisionView
     options = _.defaults options,
       diff: false
 
-    SplitDiff.disable(false)
+    @SplitDiffService?.disable()
 
     file = editor.getPath()
 
@@ -98,8 +96,6 @@ class GitRevisionView
             @_updateNewTextEditor(newTextEditor, editor, revHash, fileContents)
 
 
-
-
   @_updateNewTextEditor: (newTextEditor, editor, revHash, fileContents) ->
     # slight delay so the user gets feedback on their action
     _.delay =>
@@ -112,8 +108,7 @@ class GitRevisionView
       #  "would you like to save" message between changes to rev being viewed
       newTextEditor.buffer.cachedDiskContents = fileContents
 
-      @_splitDiff(editor, newTextEditor)
-      @_syncScroll(editor, newTextEditor)
+      @SplitDiffService?.diffEditors(editor, newTextEditor)
       @_affixTabTitle newTextEditor, revHash
     , 300
 
@@ -130,40 +125,3 @@ class GitRevisionView
       titleText += " @#{revHash}"
 
     $tabTitle.text(titleText)
-
-
-  @_splitDiff: (editor, newTextEditor) ->
-    editors =
-      editor1: newTextEditor    # the older revision
-      editor2: editor           # current rev
-
-    if not SplitDiff._getConfig 'rightEditorColor' then SplitDiff._setConfig 'rightEditorColor', 'green'
-    if not SplitDiff._getConfig 'leftEditorColor' then SplitDiff._setConfig 'leftEditorColor', 'red'
-    if not SplitDiff._getConfig 'diffWords' then SplitDiff._setConfig 'diffWords', true
-    if not SplitDiff._getConfig 'ignoreWhitespace' then SplitDiff._setConfig 'ignoreWhitespace', true
-    if not SplitDiff._getConfig 'scrollSyncType' then SplitDiff._setConfig 'scrollSyncType', 'Vertical + Horizontal'
-    
-    SplitDiff.editorSubscriptions = new CompositeDisposable()
-    SplitDiff.editorSubscriptions.add editors.editor1.onDidStopChanging =>
-      SplitDiff.updateDiff(editors) if editors?
-    SplitDiff.editorSubscriptions.add editors.editor2.onDidStopChanging =>
-      SplitDiff.updateDiff(editors) if editors?
-    SplitDiff.editorSubscriptions.add editors.editor1.onDidDestroy =>
-      editors = null;
-      SplitDiff.disable(false)
-    SplitDiff.editorSubscriptions.add editors.editor2.onDidDestroy =>
-      editors = null;
-      SplitDiff.disable(false)
-
-    SplitDiff.diffPanes()
-    SplitDiff.updateDiff editors
-
-
-  # sync scroll to editor that we are show revision for
-  @_syncScroll: (editor, newTextEditor) ->
-    # without the delay, the scroll position will fluctuate slightly beween
-    # calls to editor setText
-    _.delay =>
-      return if newTextEditor.isDestroyed()
-      newTextEditor.scrollToBufferPosition({row: @_getInitialLineNumber(editor), column: 0})
-    , 50

--- a/lib/git-time-machine.coffee
+++ b/lib/git-time-machine.coffee
@@ -44,3 +44,7 @@ module.exports = GitTimeMachine =
     if @timelinePanel.isVisible()
       @gitTimeMachineView.setEditor(editor)
     return
+
+  consumeSplitDiff: (splitDiffService) ->
+    GitRevisionView = require './git-revision-view'
+    GitRevisionView.SplitDiffService = splitDiffService

--- a/lib/git-time-machine.coffee
+++ b/lib/git-time-machine.coffee
@@ -34,9 +34,12 @@ module.exports = GitTimeMachine =
       @gitTimeMachineView.hide()
       @timelinePanel.hide()
     else
-      @timelinePanel.show()
-      @gitTimeMachineView.show()
-      @gitTimeMachineView.setEditor atom.workspace.getActiveTextEditor()
+      require('atom-package-deps').install('git-time-machine')
+        .then (->
+          @timelinePanel.show()
+          @gitTimeMachineView.show()
+          @gitTimeMachineView.setEditor atom.workspace.getActiveTextEditor()
+        ).bind(this)
 
 
   _onDidChangeActivePaneItem: (editor) ->
@@ -46,5 +49,4 @@ module.exports = GitTimeMachine =
     return
 
   consumeSplitDiff: (splitDiffService) ->
-    GitRevisionView = require './git-revision-view'
-    GitRevisionView.SplitDiffService = splitDiffService
+    require('./git-revision-view').SplitDiffService = splitDiffService

--- a/package.json
+++ b/package.json
@@ -25,8 +25,17 @@
     "d3": "3.5.6",
     "git-log-utils": "0.2.3",
     "moment": "2.10.6",
-    "split-diff": "https://github.com/mupchrch/split-diff/archive/v1.3.0.tar.gz",
     "underscore-plus": "1.x"
+  },
+  "packageDependencies": {
+    "split-diff": "^1.4.0"
+  },
+  "consumedServices": {
+    "split-diff": {
+      "versions": {
+        "1.0.0": "consumeSplitDiff"
+      }
+    }
   },
   "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
+    "atom-package-deps": "^4.0.1",
     "atom-space-pen-views": "^2.0.3",
     "bumble-strings": "0.4.1",
     "d3": "3.5.6",
@@ -27,9 +28,9 @@
     "moment": "2.10.6",
     "underscore-plus": "1.x"
   },
-  "packageDependencies": {
-    "split-diff": "^1.4.0"
-  },
+  "package-deps": [
+    "split-diff:1.4.0"
+  ],
   "consumedServices": {
     "split-diff": {
       "versions": {

--- a/styles/git-time-machine.less
+++ b/styles/git-time-machine.less
@@ -3,7 +3,6 @@
 // See https://github.com/atom/atom-dark-ui/blob/master/styles/ui-variables.less
 // for a full listing of what's available.
 @import "ui-variables";
-@import "../node_modules/split-diff/styles/split-diff.less";
 
 .git-time-machine {
   .timeplot {
@@ -30,7 +29,7 @@
   .close-handle:hover {
     background-color: red;
   }
-  
+
   .stats {
     display: inline-block;
     float: left;


### PR DESCRIPTION
This PR aims to consume `split-diff`'s new service API for diffing 2 editors.

**Benefits**
- Reduce amount of code in `git-time-machine` that was necessary to get `split-diff` working.
- Installs `split-diff` as a package so user can tweak settings via Atom settings view.
- The version of `split-diff` will stay up to date and user will get all new updates/bug fixes for it just like any other package.
- Closes #71, #108, #110, #111, and #119

**Things to note**
- Added new node module `atom-package-deps`. This module prompts the user to install `split-diff`. If user chooses "No", `git-time-machine` continues to function but no diffing occurs between the editors. Could also not prompt user and forcefully install, but figured I'd leave it as a choice.
- Service consumption needs to occur in the main js file, so the [service object is getting set](https://github.com/littlebee/git-time-machine/compare/master...mupchrch:master#diff-60f1465be14d6976e357138ad751837dR52) on GitRevisionView from there as a means of passing the object. I didn't want to pass the service object through timeplot then to timeplot popup then to revision view. This is something that I can change if you have any preference on how that should be done.