### PR TITLE
Version 2.0 of gtm

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ git-time-machine is a package for [Atom](https://atom.io/) that allows you to tr
 
 To open the timeplot, just use the keyboard shortcut <kbd>alt</kbd>+<kbd>t</kbd>.
 
+You can hold shift when clicking on the timeplot or popup to set the right side version.  If there is no left side version, or the version shift clicked is older than the left version, the older version should always display on the left because, as we all know, time travels from left to right. :)
 
 ## Troubleshooting
 

--- a/lib/git-rev-selector.coffee
+++ b/lib/git-rev-selector.coffee
@@ -1,0 +1,73 @@
+
+{$, View} = require "atom-space-pen-views"
+_ = require 'underscore-plus'
+moment = require 'moment'
+
+GitRevSelectorPopup = require './git-revselector-popup'
+
+
+module.exports = class GitRevSelector extends View
+
+  @content = (leftOrRight, commit) ->
+    dateFormat = "MMM DD YYYY ha"
+    commitLabel = ""
+    
+    if commit?
+      # commitLabel = "#{commitDate} #{revHash}"  #takes up too much space with revHash
+      commitLabel = moment.unix(commit.authorDate).format(dateFormat)
+
+    @div class: "timemachine-rev-select #{leftOrRight}-rev", =>
+      if commit == undefined 
+        return ""
+      else if commit == null
+        @leftButton() 
+        @span "Local Version"
+        @rightButton disabled: true
+      else
+        @leftButton()
+        @span commitLabel
+        @rightButton()
+
+
+  @leftButton: (options={}) ->
+    options = _.defaults options,
+      click: '_onPreviousRevClick'
+    
+    @button " < ", options
+        
+      
+  @rightButton: (options={}) ->
+    options = _.defaults options,
+      click: '_onNextRevClick'
+    
+    @button " > ", options
+    
+
+  @button: (text, options) ->
+    options = _.defaults options,
+      class: 'btn btn-small'
+    
+    @tag 'button', text, options
+
+      
+  initialize: (leftOrRight, commit, @onPreviousRevision, @onNextRevision) ->
+    $splitdiffElement = $(".tool-panel .split-diff-ui .mid")
+    $splitdiffElement.find(".timemachine-rev-select.#{leftOrRight}-rev").remove()
+    if leftOrRight == 'left'
+      $splitdiffElement.prepend @
+    else
+      $splitdiffElement.append @
+    
+    @revPopup?.hide().remove()
+    if commit?
+      @revPopup = new GitRevSelectorPopup(commit, leftOrRight, @)
+
+
+  
+
+  _onPreviousRevClick: ->
+    @onPreviousRevision?.apply(@, arguments)
+    
+  
+  _onNextRevClick: ->
+    @onNextRevision?.apply(@, arguments)

--- a/lib/git-rev-selector.coffee
+++ b/lib/git-rev-selector.coffee
@@ -28,7 +28,7 @@ module.exports = class GitRevSelector extends View
         @span commitLabel
         @rightButton()
 
-
+  
   @leftButton: (options={}) ->
     options = _.defaults options,
       click: '_onPreviousRevClick'
@@ -63,7 +63,9 @@ module.exports = class GitRevSelector extends View
       @revPopup = new GitRevSelectorPopup(commit, leftOrRight, @)
 
 
-  
+  detached: ->
+    @revPopup?.remove()
+
 
   _onPreviousRevClick: ->
     @onPreviousRevision?.apply(@, arguments)

--- a/lib/git-revision-view.coffee
+++ b/lib/git-revision-view.coffee
@@ -237,10 +237,13 @@ module.exports = class GitRevisionView
     return unless gitRevView?
 
     if editor in [gitRevView.leftRevEditor, gitRevView.rightRevEditor]
-      filePath = editor.getPath()
-      fs.unlink(filePath)
+      if editor != gitRevView.sourceEditor 
+        filePath = editor.getPath()
+        if filePath.match /\/git-time-machine\/TimeMachine \- /
+          fs.unlink(filePath)
+        else
+          console.warn "cowardly refusing to delete non gtm temp file: #{filePath}"
       delete editor.__gitTimeMachine
-    
     
     if editor == gitRevView.leftRevEditor
       unless gitRevView.rightRevEditor == gitRevView.sourceEditor

--- a/lib/git-revision-view.coffee
+++ b/lib/git-revision-view.coffee
@@ -28,7 +28,7 @@ class GitRevisionView
     thank you, @jakesankey!
 
   ###
-  @showRevision: (editor, revHash, options={}) ->
+  @showRevision: (editor, leftRevHash, rightRevHash, options={}) ->
     options = _.defaults options,
       diff: false
     
@@ -40,11 +40,11 @@ class GitRevisionView
         fileContents += output
     exit = (code) =>
       if code is 0
-        @_showRevision(file, editor, revHash, fileContents, options)
+        @_showRevision(file, editor, leftRevHash, fileContents, options)
       else
         atom.notifications.addError "Could not retrieve revision for #{path.basename(file)} (#{code})"
 
-    @_loadRevision file, revHash, stdout, exit
+    @_loadRevision file, leftRevHash, stdout, exit
 
 
   @isActivating: false

--- a/lib/git-revision-view.coffee
+++ b/lib/git-revision-view.coffee
@@ -39,11 +39,18 @@ module.exports = class GitRevisionView
   
   activateTimeMachineEditorForEditor: (editor) ->
     return unless editor in [@leftRevEditor, @rightRevEditor, @sourceEditor]
+    
+    GitRevisionView._isActivating = true
     if editor == @leftRevEditor
       rightEditor = @rightRevEditor ? @sourceEditor
       @findEditorPane(rightEditor)[0].activateItem(rightEditor)
     else
       @findEditorPane(@leftRevEditor)[0].activateItem(@leftRevEditor)
+      
+    @syncScroll(@leftRevEditor, @rightRevEditor)
+    @splitDiff(@leftRevEditor, @rightRevEditor)
+    GitRevisionView._isActivating = false
+      
 
   
   showRevision: (@sourceEditor, leftRevHash, rightRevHash, options={}) ->

--- a/lib/git-revision-view.coffee
+++ b/lib/git-revision-view.coffee
@@ -157,7 +157,15 @@ module.exports = class GitRevisionView
         @sourceEditor ?= sourceEditor
         
         unless revHash?
-          resolve(@sourceEditor)
+          unless isLeftRev
+            if @rightRevEditor? && @rightRevEditor != @sourceEditor
+              atom.workspace.open(@sourceEditor.getPath(),
+                activatePane: true
+                activateItem: true
+                searchAllPanes: true              
+              ).then =>
+                @rightRevEditor = @sourceEditor
+                resolve(@sourceEditor)
           return
         
         promise = @_createEditorForRevision(revision, fileContents, isLeftRev)

--- a/lib/git-revision-view.coffee
+++ b/lib/git-revision-view.coffee
@@ -166,6 +166,8 @@ module.exports = class GitRevisionView
               ).then =>
                 @rightRevEditor = @sourceEditor
                 resolve(@sourceEditor)
+            else
+              resolve(@sourceEditor)
           return
         
         promise = @_createEditorForRevision(revision, fileContents, isLeftRev)

--- a/lib/git-revision-view.coffee
+++ b/lib/git-revision-view.coffee
@@ -10,7 +10,7 @@ str = require('bumble-strings')
 
 module.exports = class GitRevisionView
 
-  FILE_PREFIX: "TimeMachine - "
+  FILE_PREFIX: "Time Machine - "
   
   # this is true when we are creating panes and editors for a revision. 
   @isActivating: -> 
@@ -196,10 +196,11 @@ module.exports = class GitRevisionView
   _getOutputFilePath: (file, revision, isLeftRev)->
     outputDir = "#{atom.getConfigDirPath()}/git-time-machine"
     fs.mkdirSync outputDir if not fs.existsSync outputDir
-    leftOrRight = if isLeftRev then ' left: ' else ' right: '
+    leftOrRight = if isLeftRev then 'lrev' else 'rrev'
 
-    outputPath = "#{outputDir}/#{@FILE_PREFIX} #{path.basename(file)}"
-      
+    outputPath = "#{outputDir}/#{@FILE_PREFIX}#{revision.revHash} - #{path.basename(file)}"
+    outputPath = "#{outputDir}/#{leftOrRight}/#{@FILE_PREFIX}#{path.basename(file)}"
+    
     return outputPath
     
   
@@ -234,7 +235,8 @@ module.exports = class GitRevisionView
     if editor in [gitRevView.leftRevEditor, gitRevView.rightRevEditor]
       if editor != gitRevView.sourceEditor 
         filePath = editor.getPath()
-        if filePath.match /\/git-time-machine\/TimeMachine \- /
+        regex = new RegExp "\/git-time-machine\/.*#{FILE_PREFIX}"
+        if filePath.match regex
           fs.unlink(filePath)
         else
           console.warn "cowardly refusing to delete non gtm temp file: #{filePath}"

--- a/lib/git-revision-view.coffee
+++ b/lib/git-revision-view.coffee
@@ -30,7 +30,8 @@ class GitRevisionView
     options = _.defaults options,
       diff: false
 
-    SplitDiff.disable(false)
+    # TODO : figure out why this was here. Seems to work fine without
+    # SplitDiff.disable(false)
 
     file = editor.getPath()
 

--- a/lib/git-revision-view.coffee
+++ b/lib/git-revision-view.coffee
@@ -258,7 +258,7 @@ module.exports = class GitRevisionView
 
   # starting in gtm 2.0; leftEditor = order version, rightEditor = new version
   splitDiff: (leftEditor, rightEditor) ->
-    @constructor.SplitDiffService?.diffEditors(leftEditor, rightEditor)
+    @constructor.SplitDiffService?.diffEditors(leftEditor, rightEditor, addedColorSide: 'right')
     
 
 

--- a/lib/git-revision-view.coffee
+++ b/lib/git-revision-view.coffee
@@ -47,6 +47,8 @@ class GitRevisionView
     @_loadRevision file, revHash, stdout, exit
 
 
+  @isActivating: false
+
   # returns the pane and it's index (left to right) in workspace.getPanes()
   @findEditorPane: (editor) ->
     for pane, paneIndex in atom.workspace.getPanes()
@@ -93,6 +95,7 @@ class GitRevisionView
     
     fs.writeFile outputFilePath, tempContent, (error) =>
       if not error
+        @isActivating = true
         # editor (current rev) may have been destroyed, workspace.open will find or
         # reopen it
         promise = atom.workspace.open file,
@@ -113,6 +116,7 @@ class GitRevisionView
           promise.then (newTextEditor) =>
             @_updateEditors(newTextEditor, editor, revHash, fileContents)
             pane.activate()
+            @isActivating = false
             
 
 

--- a/lib/git-revision-view.coffee
+++ b/lib/git-revision-view.coffee
@@ -168,8 +168,6 @@ module.exports = class GitRevisionView
     file = @sourceEditor.getPath()
     return new Promise (resolve, reject) =>
       outputFilePath = @_getOutputFilePath(file, revision, isLeftRev)
-      # tempContent = "Loading..." + @sourceEditor.buffer?.lineEndingForRow(0)
-      # fs.writeFileSync outputFilePath, tempContent
       
       # sourceEditor here should always be the original source doc editor (current rev)
       [sourceEditorPane, paneIndex] = @findEditorPane(@sourceEditor)
@@ -191,6 +189,7 @@ module.exports = class GitRevisionView
       promise.then (newTextEditor) =>
         @_updateEditor(newTextEditor, revision.revHash, fileContents, isLeftRev)
         revision.sourceEditor = newTextEditor
+        _.defer => sourceEditorPane.activate()
         resolve(newTextEditor)
         
         

--- a/lib/git-revision-view.coffee
+++ b/lib/git-revision-view.coffee
@@ -237,7 +237,7 @@ class GitRevisionView
       editor2: rightEditor           # current rev
 
     # TODO : not sure why these seem reversed but the display is correct with green on the right
-    SplitDiff._setConfig 'leftEditorColor', 'red  e'
+    SplitDiff._setConfig 'leftEditorColor', 'red'
     SplitDiff._setConfig 'rightEditorColor', 'green'
     SplitDiff._setConfig 'diffWords', true
     SplitDiff._setConfig 'ignoreWhitespace', true

--- a/lib/git-revselector-popup.coffee
+++ b/lib/git-revselector-popup.coffee
@@ -33,7 +33,7 @@ module.exports = class GitRevSelectorPopup extends View
     @appendTo atom.views.getView atom.workspace
     @_bindMouseEvents()
     @show()
-    _.delay @hide, 10000
+    _.delay @hide, 5000
     
     
   _bindMouseEvents: ->

--- a/lib/git-revselector-popup.coffee
+++ b/lib/git-revselector-popup.coffee
@@ -1,0 +1,98 @@
+{$, View} = require "atom-space-pen-views"
+moment = require 'moment'
+_ = require 'underscore-plus'
+
+
+module.exports = class GitRevSelectorPopup extends View
+
+  @content = (commit, leftOrRight, $hoverElement) ->
+    dateFormat = "MMM DD YYYY ha"
+    @div class: "select-list popover-list git-timemachine-revselector-popup", =>
+      authorDate = moment.unix(commit.authorDate)
+      linesAdded = commit.linesAdded || 0
+      linesDeleted = commit.linesDeleted || 0
+      @div "data-rev": commit.id, =>
+        @div class: "commit", =>
+          @div class: "header", =>
+            @div "#{authorDate.format(dateFormat)}"
+            @div "#{commit.hash}"
+            @div =>
+              @span class: 'added-count', "+#{linesAdded} "
+              @span class: 'removed-count', "-#{linesDeleted} "
+
+          @div =>
+            @strong "#{commit.message}"
+
+          @div "Authored by #{commit.authorName} #{authorDate.fromNow()}"
+
+
+  initialize: (commit, @leftOrRight, @$hoverElement) ->
+    # allows time to get mouse in popup
+    @_debouncedHide ?= _.debounce @hide, 50 
+    
+    @appendTo atom.views.getView atom.workspace
+    @_bindMouseEvents()
+    @show()
+    _.delay @hide, 10000
+    
+    
+  _bindMouseEvents: ->
+    @mouseenter @_onMouseEnterPopup
+    @mouseleave @_onMouseLeavePopup
+    @$hoverElement.mouseenter @_onMouseEnterHoverElement
+    @$hoverElement.mouseleave @_onMouseLeaveHoverElement
+
+    
+  hide: () =>
+    unless @_mouseInPopup || @_mouseInHoverElement
+      super
+      
+    return @
+
+
+  show: () =>
+    super
+    _.defer => @_positionPopup()
+      
+    return @
+
+
+  remove: () =>
+    super
+
+
+  isMouseInPopup: () =>
+    return @_mouseInPopup == true
+
+
+  _positionPopup: ->
+    clientRect = @$hoverElement.offset()
+    if @leftOrRight == 'left'
+      left = clientRect.left + @$hoverElement.width() - @width()
+    else
+      left = clientRect.left
+    top = clientRect.top - @height() - 18
+    @css({top: top, left: left})
+
+
+  _onMouseEnterPopup: (evt) =>
+    @_mouseInPopup = true
+    return
+
+
+  _onMouseLeavePopup: (evt) =>
+    @_mouseInPopup = false
+    @_debouncedHide()
+    return
+    
+    
+  _onMouseEnterHoverElement: (evt) =>
+    @_mouseInHoverElement = true
+    @show()
+    
+
+  _onMouseLeaveHoverElement: (evt) =>
+    @_mouseInHoverElement = false
+    @_debouncedHide()
+
+

--- a/lib/git-time-machine-view.coffee
+++ b/lib/git-time-machine-view.coffee
@@ -19,17 +19,17 @@ class GitTimeMachineView
       @render()
       
     @_bindWindowEvents()
-
+    
 
   setEditor: (editor) ->
-    return if !editor? || editor == @lastActivatedEditor || GitRevisionView.isActivating 
+    return if !editor? || editor == @lastActivatedEditor || GitRevisionView.isActivating() 
       
     file = editor.getPath()
     return unless file?
     
     @lastActivatedEditor = editor
     @render()
-    @loadExistingRevForEditor()
+    GitRevisionView.loadExistingRevForEditor(editor)
 
 
   render: () ->
@@ -70,8 +70,7 @@ class GitTimeMachineView
 
 
   gitCommitHistory: (editor=@lastActivatedEditor)->
-    # get the file name of the original file if on a timemachine editor
-    file = editor?.__gitTimeMachine?.sourceEditor?.getPath() || editor?.getPath()
+    file = editor?.getPath()
     return null unless file?
     
     try
@@ -87,49 +86,6 @@ class GitTimeMachineView
       return null
 
     return commits;
-
-
-  loadExistingRevForEditor: (editor=@lastActivatedEditor) ->
-    return unless editor.__gitTimeMachine?
-    
-    _.defer =>
-      return unless editor.__gitTimeMachine?
-      sourceEditor = editor.__gitTimeMachine.sourceEditor
-      
-      @activateTimeMachineEditorForEditor(sourceEditor) unless editor.isDestroyed()
-      
-      leftEditor = sourceEditor.__gitTimeMachine.leftRevEditor 
-      rightEditor = sourceEditor.__gitTimeMachine.rightRevEditor 
-      GitRevisionView.splitDiff(leftEditor, rightEditor)
-      GitRevisionView.syncScroll(leftEditor, rightEditor)
-    
-    
-  destroyEditor: (editor=@lastActivatedEditor) ->
-    return unless editor.__gitTimeMachine?
-    sourceEditor = editor.__gitTimeMachine.sourceEditor
-    
-    if editor == sourceEditor
-      leftRevEditor = sourceEditor.__gitTimeMachine.leftRevEditor
-      rightRevEditor = sourceEditor.__gitTimeMachine.rightRevEditor
-      
-      revEditors = _.filter [leftRevEditor, rightRevEditor], (e) -> 
-        e != sourceEditor && !e.isDestroyed()
-        
-      revEditor.destroy() for revEditor in revEditors
-
-    
-  # editor should be the source editor
-  activateTimeMachineEditorForEditor: (sourceEditor) ->
-    return unless sourceEditor.__gitTimeMachine?
-    
-    leftRevEditor = sourceEditor.__gitTimeMachine.leftRevEditor
-    leftRevPane = GitRevisionView.findEditorPane(leftRevEditor)[0]
-    leftRevPane?.activateItem(leftRevEditor) unless leftRevEditor == @lastActivatedEditor
-    
-    rightRevEditor = sourceEditor.__gitTimeMachine.rightRevEditor
-    # the rightRevPane should always be the same pane as the source editor pane
-    rightRevPane = GitRevisionView.findEditorPane(sourceEditor)[0]
-    rightRevPane?.activateItem(rightRevEditor) unless rightRevEditor == @lastActivatedEditor
 
 
   _bindWindowEvents: () ->

--- a/lib/git-time-machine-view.coffee
+++ b/lib/git-time-machine-view.coffee
@@ -139,16 +139,23 @@ class GitTimeMachineView
 
   
   _onViewRevision: (revHash, reverse) =>
-    [leftRevHash, rightRevHash] = if reverse
-      [@leftRevHash, revHash]
+    leftRevHash = null
+    rightRevHash = null
+    
+    if @lastActivatedEditor.__gitTimeMachine?
+      leftRevHash = @lastActivatedEditor.__gitTimeMachine.revisions?[0]?.revHash ? null
+      rightRevHash = @lastActivatedEditor.__gitTimeMachine.revisions?[1]?.revHash ? null
+      
+    if reverse
+      rightRevHash = revHash
     else
-      [revHash, @rightRevHash]
+      leftRevHash = revHash
     
     # order by created asc
-    [@leftRevHash, @rightRevHash] = @_orderRevHashes(leftRevHash, rightRevHash)
+    [leftRevHash, rightRevHash] = @_orderRevHashes(leftRevHash, rightRevHash)
     
-    GitRevisionView.showRevision(@lastActivatedEditor, @leftRevHash, @rightRevHash)
-    @timeplot.setRevisions(@leftRevHash, @rightRevHash)
+    GitRevisionView.showRevision(@lastActivatedEditor, leftRevHash, rightRevHash)
+    @timeplot.setRevisions(leftRevHash, rightRevHash)
     
     
       

--- a/lib/git-time-machine-view.coffee
+++ b/lib/git-time-machine-view.coffee
@@ -85,7 +85,6 @@ class GitTimeMachineView
 
 
 
-
   _bindWindowEvents: () ->
     $(window).on 'resize', @_onEditorResize 
     
@@ -110,7 +109,6 @@ class GitTimeMachineView
       atom.commands.dispatch(atom.views.getView(atom.workspace), "git-time-machine:toggle")
 
 
-
   _renderTimeplot: (commits) ->
     @timeplot ||= new GitTimeplot(@$element)
     @timeplot.render(@editor, commits, @_onViewRevision)
@@ -133,14 +131,10 @@ class GitTimeMachineView
     return
 
   
-  _onViewRevision: (revHash) =>
-    GitRevisionView.showRevision(@editor, revHash)
+  _onViewRevision: (revHash, reverse) =>
+    GitRevisionView.showRevision(@editor, revHash, {reverse: reverse})
     
       
-     
-    
-
-
   _onEditorResize: =>
     @render()
     

--- a/lib/git-time-machine-view.coffee
+++ b/lib/git-time-machine-view.coffee
@@ -164,13 +164,18 @@ class GitTimeMachineView
     # order by created asc
     [leftRevHash, rightRevHash] = @_orderRevHashes(leftRevHash, rightRevHash)
     
-    GitRevisionView.showRevision(@lastActivatedEditor, leftRevHash, rightRevHash)
+    GitRevisionView.showRevision(@lastActivatedEditor, leftRevHash, rightRevHash, @_onRevisionClose)
     @timeplot.setRevisions(leftRevHash, rightRevHash)
     
     
       
   _onEditorResize: =>
     @render()
+    
+    
+  _onRevisionClose: =>
+    rightRevHash = leftRevHash = null
+    @timeplot.setRevisions(leftRevHash, rightRevHash)
     
     
   _orderRevHashes: (revHashA, revHashB) ->

--- a/lib/git-time-machine-view.coffee
+++ b/lib/git-time-machine-view.coffee
@@ -119,6 +119,16 @@ class GitTimeMachineView
   _renderTimeplot: (commits) ->
     @timeplot ||= new GitTimeplot(@$element)
     @timeplot.render(commits, @_onViewRevision)
+    
+    leftRevHash = null
+    rightRevHash = null
+    
+    if @lastActivatedEditor.__gitTimeMachine?
+      leftRevHash = @lastActivatedEditor.__gitTimeMachine.revisions?[0]?.revHash
+      rightRevHash = @lastActivatedEditor.__gitTimeMachine.revisions?[1]?.revHash
+    
+    @timeplot.setRevisions(leftRevHash, rightRevHash)    
+    
     return
 
 

--- a/lib/git-time-machine-view.coffee
+++ b/lib/git-time-machine-view.coffee
@@ -70,6 +70,10 @@ class GitTimeMachineView
 
 
   gitCommitHistory: (editor=@lastActivatedEditor)->
+    return null unless editor?
+    if editor.__gitTimeMachine?.sourceEditor?
+      editor = editor.__gitTimeMachine.sourceEditor
+    
     file = editor?.getPath()
     return null unless file?
     

--- a/lib/git-time-machine-view.coffee
+++ b/lib/git-time-machine-view.coffee
@@ -22,8 +22,9 @@ class GitTimeMachineView
 
 
   setEditor: (editor) ->
-    return if !editor? || editor == @lastActivatedEditor || GitRevisionView.isActivating
-    file = editor?.getPath()
+    return if !editor? || editor == @lastActivatedEditor || GitRevisionView.isActivating 
+      
+    file = editor.getPath()
     return unless file?
     
     @lastActivatedEditor = editor
@@ -109,9 +110,11 @@ class GitTimeMachineView
     
     if editor == sourceEditor
       leftRevEditor = sourceEditor.__gitTimeMachine.leftRevEditor
-      rightRevEditor = sourceEditor__gitTimeMachine.rightRevEditor
+      rightRevEditor = sourceEditor.__gitTimeMachine.rightRevEditor
       
-      revEditors = _.filter [leftRevEditor, rightRevEditor], (e) -> e != sourceEditor
+      revEditors = _.filter [leftRevEditor, rightRevEditor], (e) -> 
+        e != sourceEditor && !e.isDestroyed()
+        
       revEditor.destroy() for revEditor in revEditors
 
     

--- a/lib/git-time-machine-view.coffee
+++ b/lib/git-time-machine-view.coffee
@@ -92,6 +92,8 @@ class GitTimeMachineView
     return unless editor.__gitTimeMachine?
     
     _.defer =>
+      return unless editor.__gitTimeMachine?
+      
       [sourceEditor, revEditor] = [editor.__gitTimeMachine.sourceEditor, editor.__gitTimeMachine.leftRevEditor]
       unless sourceEditor.isDestroyed() || revEditor.isDestroyed()
         @activateTimeMachineEditorForEditor(editor) unless editor.isDestroyed()

--- a/lib/git-time-machine-view.coffee
+++ b/lib/git-time-machine-view.coffee
@@ -124,9 +124,9 @@ class GitTimeMachineView
     # null unless in a Time Machine - ... tab
     returnEditor = null
     fileName = editor.getPath?()
-    tmRevFileName = editor.__gitTimeMachine?.sourceEditor?.getPath()
+    leftRevFileName = editor.__gitTimeMachine?.sourceEditor?.getPath()
     
-    return null if !(fileName? || tmRevFileName?) || !editor.__gitTimeMachine?
+    return null if !(fileName? || leftRevFileName?) || !editor.__gitTimeMachine?
     
     sourceEditor = editor.__gitTimeMachine.sourceEditor
     leftRevEditor = editor.__gitTimeMachine.leftRevEditor
@@ -167,7 +167,7 @@ class GitTimeMachineView
 
   _renderTimeplot: (commits) ->
     @timeplot ||= new GitTimeplot(@$element)
-    @timeplot.render(@editor, commits, @_onViewRevision)
+    @timeplot.render(commits, @_onViewRevision)
     return
 
 
@@ -189,6 +189,7 @@ class GitTimeMachineView
   
   _onViewRevision: (@leftRevHash, reverse) =>
     GitRevisionView.showRevision(@editor, @leftRevHash, {reverse: reverse})
+    @timeplot.setRevisions(@leftRevHash, null)
     
     
       

--- a/lib/git-time-machine-view.coffee
+++ b/lib/git-time-machine-view.coffee
@@ -187,12 +187,35 @@ class GitTimeMachineView
     return
 
   
-  _onViewRevision: (@leftRevHash, reverse) =>
-    GitRevisionView.showRevision(@editor, @leftRevHash, {reverse: reverse})
-    @timeplot.setRevisions(@leftRevHash, null)
+  _onViewRevision: (revHash, reverse) =>
+    [leftRevHash, rightRevHash] = if reverse
+      [@leftRevHash, revHash]
+    else
+      [revHash, @rightRevHash]
+    
+    # order by created asc
+    [@leftRevHash, @rightRevHash] = @_orderRevHashes(leftRevHash, rightRevHash)
+    
+    GitRevisionView.showRevision(@editor, @leftRevHash, @rightRevHash)
+    @timeplot.setRevisions(@leftRevHash, @rightRevHash)
     
     
       
   _onEditorResize: =>
     @render()
     
+    
+  _orderRevHashes: (revHashA, revHashB) ->
+    unorderedRevs = [revHashA, revHashB]
+    return unorderedRevs unless @commits?.length > 0
+    
+    orderedRevs = []
+    for rev in @commits
+      if rev.id in unorderedRevs || rev.hash in unorderedRevs
+        orderedRevs.push rev.hash
+        break if orderedRevs.length >= 2
+        
+    return orderedRevs.reverse()    
+    
+      
+  

--- a/lib/git-time-machine-view.coffee
+++ b/lib/git-time-machine-view.coffee
@@ -24,20 +24,22 @@ class GitTimeMachineView
   setEditor: (editor) ->
     return unless editor != @editor
     file = editor?.getPath()
+    
+    # don't try to process our temp rev file
     return unless file? && !str.startsWith(path.basename(file), GitRevisionView.FILE_PREFIX)
     [@editor, @file] = [editor, file]
     @render()
 
 
   render: () ->
-    commits = @gitCommitHistory()
-    unless @file? && commits?
+    @commits = @gitCommitHistory()
+    unless @file? && @commits?
       @_renderPlaceholder()
     else
       @$element.text("")
       @_renderCloseHandle()
-      @_renderStats(commits)
-      @_renderTimeline(commits)
+      @_renderTimeplot(@commits)
+      @_renderStats(@commits)
 
     return @$element
 
@@ -109,9 +111,9 @@ class GitTimeMachineView
 
 
 
-  _renderTimeline: (commits) ->
+  _renderTimeplot: (commits) ->
     @timeplot ||= new GitTimeplot(@$element)
-    @timeplot.render(@editor, commits)
+    @timeplot.render(@editor, commits, @_onViewRevision)
     return
 
 
@@ -129,6 +131,14 @@ class GitTimeMachineView
       </div>
     """
     return
+
+  
+  _onViewRevision: (revHash) =>
+    GitRevisionView.showRevision(@editor, revHash)
+    
+      
+     
+    
 
 
   _onEditorResize: =>

--- a/lib/git-time-machine.coffee
+++ b/lib/git-time-machine.coffee
@@ -16,7 +16,6 @@ module.exports = GitTimeMachine =
     # Register command that toggles this view
     @subscriptions.add atom.commands.add 'atom-workspace', 'git-time-machine:toggle': => @toggle()
     @subscriptions.add atom.workspace.onDidChangeActivePaneItem((editor) => @_onDidChangeActivePaneItem(editor))
-    @subscriptions.add atom.workspace.onWillDestroyPaneItem((paneInfo) => @_onWillDestroyPaneItem(paneInfo))
 
 
   deactivate: ->
@@ -46,8 +45,5 @@ module.exports = GitTimeMachine =
       @gitTimeMachineView.setEditor(editor)
     return
   
-  
-  _onWillDestroyPaneItem: (paneInfo) ->
-    @gitTimeMachineView.destroyEditor(paneInfo.item)
     
     

--- a/lib/git-time-machine.coffee
+++ b/lib/git-time-machine.coffee
@@ -48,5 +48,6 @@ module.exports = GitTimeMachine =
       @gitTimeMachineView.setEditor(editor)
     return
 
+
   consumeSplitDiff: (splitDiffService) ->
     require('./git-revision-view').SplitDiffService = splitDiffService

--- a/lib/git-time-machine.coffee
+++ b/lib/git-time-machine.coffee
@@ -6,6 +6,7 @@ module.exports = GitTimeMachine =
   timelinePanel: null
   subscriptions: null
 
+
   activate: (state) ->
     @gitTimeMachineView = new GitTimeMachineView state.gitTimeMachineViewState
     @timelinePanel = atom.workspace.addBottomPanel(item: @gitTimeMachineView.getElement(), visible: false)
@@ -14,7 +15,10 @@ module.exports = GitTimeMachine =
     @subscriptions = new CompositeDisposable
 
     # Register command that toggles this view
-    @subscriptions.add atom.commands.add 'atom-workspace', 'git-time-machine:toggle': => @toggle()
+    @subscriptions.add atom.commands.add 'atom-workspace', 
+      'git-time-machine:toggle': => @toggle()
+      'core:cancel': () => @timelinePanel?.isVisible() && @toggle()
+    
     @subscriptions.add atom.workspace.onDidChangeActivePaneItem((editor) => @_onDidChangeActivePaneItem(editor))
 
 

--- a/lib/git-time-machine.coffee
+++ b/lib/git-time-machine.coffee
@@ -15,7 +15,8 @@ module.exports = GitTimeMachine =
 
     # Register command that toggles this view
     @subscriptions.add atom.commands.add 'atom-workspace', 'git-time-machine:toggle': => @toggle()
-    atom.workspace.onDidChangeActivePaneItem (editor) => @_onDidChangeActivePaneItem()
+    @subscriptions.add atom.workspace.onDidChangeActivePaneItem((editor) => @_onDidChangeActivePaneItem(editor))
+    @subscriptions.add atom.workspace.onWillDestroyPaneItem((paneInfo) => @_onWillDestroyPaneItem(paneInfo))
 
 
   deactivate: ->
@@ -40,7 +41,13 @@ module.exports = GitTimeMachine =
 
 
   _onDidChangeActivePaneItem: (editor) ->
-    editor = atom.workspace.getActiveTextEditor()
     if @timelinePanel.isVisible()
+      editor = atom.workspace.getActiveTextEditor()
       @gitTimeMachineView.setEditor(editor)
     return
+  
+  
+  _onWillDestroyPaneItem: (paneInfo) ->
+    @gitTimeMachineView.destroyEditor(paneInfo.item)
+    
+    

--- a/lib/git-timeplot-popup.coffee
+++ b/lib/git-timeplot-popup.coffee
@@ -8,7 +8,7 @@ module.exports = class GitTimeplotPopup extends View
     commitVerb = commitData.length > 0 ? "were" : "was"
     commitSuffix = commitData.length > 0 ? "s" : ""
     @div class: "select-list popover-list git-timemachine-popup", =>
-      @h5 "There #{commitVerb} #{commitData.length} commit{#commitSuffix} between"
+      @h5 "There #{commitVerb} #{commitData.length} commit#{commitSuffix} between"
       @h6 "#{start.format(dateFormat)} and #{end.format(dateFormat)}"
       @ul =>
         for commit in commitData

--- a/lib/git-timeplot-popup.coffee
+++ b/lib/git-timeplot-popup.coffee
@@ -3,7 +3,7 @@ moment = require 'moment'
 
 module.exports = class GitTimeplotPopup extends View
 
-  @content = (editor, commitData, start, end) ->
+  @content = (commitData, start, end) ->
     dateFormat = "MMM DD YYYY ha"
     @div class: "select-list popover-list git-timemachine-popup", =>
       @h5 "There were #{commitData.length} commits between"
@@ -13,7 +13,7 @@ module.exports = class GitTimeplotPopup extends View
           authorDate = moment.unix(commit.authorDate)
           linesAdded = commit.linesAdded || 0
           linesDeleted = commit.linesDeleted || 0
-          @li "data-rev": commit.hash, click: '_onShowRevision', =>
+          @li "data-rev": commit.id, click: '_onRevisionClick', =>
             @div class: "commit", =>
               @div class: "header", =>
                 @div "#{authorDate.format(dateFormat)}"
@@ -28,8 +28,7 @@ module.exports = class GitTimeplotPopup extends View
               @div "Authored by #{commit.authorName} #{authorDate.fromNow()}"
 
 
-  initialize: (@editor, commitData, start, end, @onViewRevision) ->
-    @file = @editor.getPath()
+  initialize: (commitData, start, end, @onViewRevision) ->
     @appendTo atom.views.getView atom.workspace
     @mouseenter @_onMouseEnter
     @mouseleave @_onMouseLeave
@@ -60,6 +59,6 @@ module.exports = class GitTimeplotPopup extends View
     return
 
 
-  _onShowRevision: (evt) =>
+  _onRevisionClick: (evt) =>
     revHash = $(evt.target).closest('li').data('rev')
-    @onViewRevision(revHash)
+    @onViewRevision(revHash, evt.shiftKey)

--- a/lib/git-timeplot-popup.coffee
+++ b/lib/git-timeplot-popup.coffee
@@ -5,8 +5,8 @@ module.exports = class GitTimeplotPopup extends View
 
   @content = (commitData, start, end) ->
     dateFormat = "MMM DD YYYY ha"
-    commitVerb = commitData.length > 0 ? "were" : "was"
-    commitSuffix = commitData.length > 0 ? "s" : ""
+    commitVerb = if commitData.length > 0 then "were" else "was"
+    commitSuffix = if commitData.length > 0 then "s" else ""
     @div class: "select-list popover-list git-timemachine-popup", =>
       @h5 "There #{commitVerb} #{commitData.length} commit#{commitSuffix} between"
       @h6 "#{start.format(dateFormat)} and #{end.format(dateFormat)}"

--- a/lib/git-timeplot-popup.coffee
+++ b/lib/git-timeplot-popup.coffee
@@ -1,12 +1,9 @@
 moment = require 'moment'
 {$, View} = require "atom-space-pen-views"
 
-RevisionView = require './git-revision-view'
-
-
 module.exports = class GitTimeplotPopup extends View
 
-  @content = (commitData, editor, start, end) ->
+  @content = (editor, commitData, start, end) ->
     dateFormat = "MMM DD YYYY ha"
     @div class: "select-list popover-list git-timemachine-popup", =>
       @h5 "There were #{commitData.length} commits between"
@@ -31,7 +28,7 @@ module.exports = class GitTimeplotPopup extends View
               @div "Authored by #{commit.authorName} #{authorDate.fromNow()}"
 
 
-  initialize: (commitData, @editor) ->
+  initialize: (@editor, commitData, start, end, @onViewRevision) ->
     @file = @editor.getPath()
     @appendTo atom.views.getView atom.workspace
     @mouseenter @_onMouseEnter
@@ -65,5 +62,4 @@ module.exports = class GitTimeplotPopup extends View
 
   _onShowRevision: (evt) =>
     revHash = $(evt.target).closest('li').data('rev')
-    RevisionView.showRevision(@editor, revHash)
-
+    @onViewRevision(revHash)

--- a/lib/git-timeplot-popup.coffee
+++ b/lib/git-timeplot-popup.coffee
@@ -8,27 +8,36 @@ module.exports = class GitTimeplotPopup extends View
     commitVerb = if commitData.length > 0 then "were" else "was"
     commitSuffix = if commitData.length > 0 then "s" else ""
     @div class: "select-list popover-list git-timemachine-popup", =>
-      @h5 "There #{commitVerb} #{commitData.length} commit#{commitSuffix} between"
-      @h6 "#{start.format(dateFormat)} and #{end.format(dateFormat)}"
-      @ul =>
-        for commit in commitData
-          authorDate = moment.unix(commit.authorDate)
-          linesAdded = commit.linesAdded || 0
-          linesDeleted = commit.linesDeleted || 0
-          @li "data-rev": commit.id, click: '_onRevisionClick', =>
-            @div class: "commit", =>
-              @div class: "header", =>
-                @div "#{authorDate.format(dateFormat)}"
-                @div "#{commit.hash}"
+      @div class: 'rev-scroller', =>
+        @h5 "There #{commitVerb} #{commitData.length} commit#{commitSuffix} between"
+        @h6 "#{start.format(dateFormat)} and #{end.format(dateFormat)}"
+        @ul =>
+          for commit in commitData
+            authorDate = moment.unix(commit.authorDate)
+            linesAdded = commit.linesAdded || 0
+            linesDeleted = commit.linesDeleted || 0
+            @li "data-rev": commit.id, click: '_onRevisionClick', =>
+              @div class: "commit", =>
+                @div class: "header", =>
+                  @div "#{authorDate.format(dateFormat)}"
+                  @div "#{commit.hash}"
+                  @div =>
+                    @span class: 'added-count', "+#{linesAdded} "
+                    @span class: 'removed-count', "-#{linesDeleted} "
+
                 @div =>
-                  @span class: 'added-count', "+#{linesAdded} "
-                  @span class: 'removed-count', "-#{linesDeleted} "
+                  @strong "#{commit.message}"
 
-              @div =>
-                @strong "#{commit.message}"
-
-              @div "Authored by #{commit.authorName} #{authorDate.fromNow()}"
-
+                @div "Authored by #{commit.authorName} #{authorDate.fromNow()}"
+      @div class: 'helper-text', =>
+        @div class: 'click-help', =>
+          @b "click"
+          @span " to select left revision"
+        
+        @div class: 'shift-click-help', =>
+          @b "shift+click"
+          @span " to select right revision"
+        
 
   initialize: (commitData, start, end, @onViewRevision) ->
     @appendTo atom.views.getView atom.workspace

--- a/lib/git-timeplot.coffee
+++ b/lib/git-timeplot.coffee
@@ -50,6 +50,7 @@ module.exports = class GitTimeplot
 
     @_renderHoverMarker()
     @_renderRevMarkers()
+    @_renderRevSelectors()
     @_bindMouseEvents()
 
     return @$timeplot;
@@ -57,7 +58,8 @@ module.exports = class GitTimeplot
   
   setRevisions: (@leftRevHash, @rightRevHash) ->
     @_renderRevMarkers()
-
+    @_renderRevSelectors()
+    
 
   _renderAxis: (svg) ->
     w = @$element.width()
@@ -137,6 +139,36 @@ module.exports = class GitTimeplot
     return unless commit?
     
     $revMarker.show().css 'left', @x(moment.unix(commit.authorDate).toDate())
+    
+    
+  _renderRevSelectors: () ->
+    _.delay =>
+      @_renderRevSelector('left')
+      @_renderRevSelector('right')
+    , 3000
+  
+  
+  # renders the select components in the SplitDiff bottom control panel
+  _renderRevSelector: (whichRev) ->
+    dateFormat = "MMM DD YYYY ha"
+    revHash = @["#{whichRev}RevHash"]
+    commit = @_findCommit(revHash)
+    return unless commit?
+    
+    commitDate = moment.unix(commit.authorDate).format(dateFormat)
+    # commitLabel = "#{commitDate} #{revHash}"  #takes up too much space with revHash
+    commitLabel = "#{commitDate}"
+    
+    $splitdiffElement = $(".tool-panel .split-diff-ui .mid")
+    $ourElement = $splitdiffElement.find(".timemachine-rev-select.#{whichRev}-rev")
+    unless $ourElement?.length > 0
+      $ourElement = $("<span class='timemachine-rev-select #{whichRev}-rev'/>")
+      if whichRev == 'left'
+        $splitdiffElement.prepend $ourElement
+      else
+        $splitdiffElement.append $ourElement
+    
+    $ourElement.text commitLabel
     
 
   _bindMouseEvents: () =>

--- a/lib/git-timeplot.coffee
+++ b/lib/git-timeplot.coffee
@@ -134,14 +134,17 @@ module.exports = class GitTimeplot
       @$element.append($revMarker)
     
     revHash = @["#{whichRev}RevHash"]
-    unless revHash?
-      $revMarker.show().css('right', 10)
+    commit = @_findCommit(revHash)
+    
+    unless commit?
+      # console.log "resetting revMarker", whichRev, revHash, commit
+      $revMarker.show().css({left: 'initial', right: 10})
       return
     
-    commit = @_findCommit(revHash)
-    return unless commit?
-    
-    $revMarker.show().css 'left', @x(moment.unix(commit.authorDate).toDate())
+    # console.log "setting revMarker", whichRev, revHash, commit
+    $revMarker.show().css 
+      left: @x(moment.unix(commit.authorDate).toDate())
+      right: 'initial'
     
     
   _renderRevSelectors: () ->

--- a/lib/git-timeplot.coffee
+++ b/lib/git-timeplot.coffee
@@ -5,8 +5,6 @@ moment = require 'moment'
 d3 = require 'd3'
 
 GitTimeplotPopup = require './git-timeplot-popup'
-RevisionView = require './git-revision-view'
-
 
 
 module.exports = class GitTimeplot
@@ -28,7 +26,7 @@ module.exports = class GitTimeplot
 
   # @commitData - array of javascript objects like those returned by GitUtils.getFileCommitHistory
   #               should be in reverse chron order
-  render: (@editor, @commitData) ->
+  render: (@editor, @commitData, @onViewRevision) ->
     @popup?.remove()
 
     @file = @editor.getPath()
@@ -148,6 +146,11 @@ module.exports = class GitTimeplot
 
   _onMouseup: (evt) ->
     @isMouseDown = false
+    
+    
+  _onViewRevision: (revHash) =>
+    # pass along up the component stack
+    @onViewRevision(revHash)
 
 
   _renderPopup: () ->
@@ -163,7 +166,7 @@ module.exports = class GitTimeplot
 
     @popup?.hide().remove()
     [commits, start, end] = @_filterCommitData(@commitData)
-    @popup = new GitTimeplotPopup(commits, @editor, start, end)
+    @popup = new GitTimeplotPopup(@editor, commits, start, end, @_onViewRevision)
 
     left = @$hoverMarker.offset().left
     if left + @popup.outerWidth() + 10 > @$element.offset().left + @$element.width()
@@ -207,4 +210,4 @@ module.exports = class GitTimeplot
   _viewNearestRevision: () ->
     nearestCommit =  @_getNearestCommit()
     if nearestCommit?
-      RevisionView.showRevision(@editor, nearestCommit.hash)
+      @_onViewRevision(nearestCommit)

--- a/lib/git-timeplot.coffee
+++ b/lib/git-timeplot.coffee
@@ -14,7 +14,7 @@ module.exports = class GitTimeplot
     @_debouncedRenderPopup = _.debounce(@_renderPopup, 50)
     @_debouncedHidePopup = _.debounce(@_hidePopup, 50)
     @_debouncedViewNearestRevision = _.debounce(@_viewNearestRevision, 100)
-    @leftRevHash = undefined    # don't show a left rev until the user selects a rev
+    @leftRevHash = undefined    # don't show a left rev marker until the user selects a rev
     @rightRevHash = null
 
 
@@ -130,10 +130,7 @@ module.exports = class GitTimeplot
     
     revHash = @["#{whichRev}RevHash"]
     unless revHash?
-      if revHash == null
-        $revMarker.show().css('right', 10)
-      else
-        $revMarker.hide()
+      $revMarker.show().css('right', 10)
       return
     
     commit = @_findCommit(revHash)
@@ -179,7 +176,7 @@ module.exports = class GitTimeplot
   _onMousedown: (evt) ->
     @isMouseDown = true
     @_hidePopup(force: true)
-    @_debouncedViewNearestRevision()
+    @_debouncedViewNearestRevision(evt.shiftKey)
 
 
   _onMouseup: (evt) ->
@@ -233,6 +230,7 @@ module.exports = class GitTimeplot
     relativeLeft = left - @$element.offset().left - 5
     tStart = moment(@x.invert(relativeLeft)).startOf('hour').subtract(1, 'minute')
     tEnd = moment(@x.invert(relativeLeft + 10)).endOf('hour').add(1, 'minute')
+    
     commits = _.filter @commitData, (c) -> moment.unix(c.authorDate).isBetween(tStart, tEnd)
     # console.log("gtm: inspecting #{commits.length} commits betwee #{tStart.toString()} - #{tEnd.toString()}")
     return [commits, tStart, tEnd];

--- a/lib/git-timeplot.coffee
+++ b/lib/git-timeplot.coffee
@@ -305,6 +305,6 @@ module.exports = class GitTimeplot
       return @commitData[index].id
     
     # @commitData is in reverse chronological order 
-    return @commitData[findOutput.index - offset].id
+    return @commitData[findOutput.index - offset]?.id
       
     

--- a/lib/git-timeplot.coffee
+++ b/lib/git-timeplot.coffee
@@ -5,6 +5,7 @@ moment = require 'moment'
 d3 = require 'd3'
 
 GitTimeplotPopup = require './git-timeplot-popup'
+GitRevSelectorPopup = require './git-revselector-popup'
 
 
 module.exports = class GitTimeplot
@@ -28,6 +29,8 @@ module.exports = class GitTimeplot
 
   # @commitData - array of javascript objects like those returned by GitUtils.getFileCommitHistory
   #               should be in reverse chron order
+  # @onViewRevision - callback method called when a revision is selected in the timeplot. Also passed
+  #               to GitRevSelector.   Sould probably be a constructor argument
   render: (@commitData, @onViewRevision) ->
     @popup?.remove()
 
@@ -142,6 +145,7 @@ module.exports = class GitTimeplot
     
     
   _renderRevSelectors: () ->
+    # have to allow suffient time for splitdiff to render
     _.delay =>
       @_renderRevSelector('left')
       @_renderRevSelector('right')
@@ -169,6 +173,11 @@ module.exports = class GitTimeplot
         $splitdiffElement.append $ourElement
     
     $ourElement.text commitLabel
+    
+    @["#{whichRev}RevPopup"]?.hide().remove()
+    @["#{whichRev}RevPopup"] = new GitRevSelectorPopup(commit, whichRev, $ourElement)
+    
+    return $ourElement
     
 
   _bindMouseEvents: () =>

--- a/lib/git-timeplot.coffee
+++ b/lib/git-timeplot.coffee
@@ -126,7 +126,7 @@ module.exports = class GitTimeplot
 
     if @isMouseDown
       @_hidePopup(force: true)
-      @_debouncedViewNearestRevision()
+      @_debouncedViewNearestRevision(evt.shiftKey)
     else
       @_debouncedRenderPopup()
 
@@ -148,9 +148,9 @@ module.exports = class GitTimeplot
     @isMouseDown = false
     
     
-  _onViewRevision: (revHash) =>
+  _onViewRevision: (revHash, reverse) =>
     # pass along up the component stack
-    @onViewRevision(revHash)
+    @onViewRevision(revHash, reverse)
 
 
   _renderPopup: () ->
@@ -166,7 +166,7 @@ module.exports = class GitTimeplot
 
     @popup?.hide().remove()
     [commits, start, end] = @_filterCommitData(@commitData)
-    @popup = new GitTimeplotPopup(@editor, commits, start, end, @_onViewRevision)
+    @popup = new GitTimeplotPopup(commits, start, end, @_onViewRevision)
 
     left = @$hoverMarker.offset().left
     if left + @popup.outerWidth() + 10 > @$element.offset().left + @$element.width()
@@ -207,7 +207,7 @@ module.exports = class GitTimeplot
       return _.find @commitData, (c) -> moment.unix(c.authorDate).isBefore(tEnd)
 
 
-  _viewNearestRevision: () ->
+  _viewNearestRevision: (reverse) ->
     nearestCommit =  @_getNearestCommit()
     if nearestCommit?
-      @_onViewRevision(nearestCommit)
+      @_onViewRevision(nearestCommit.id, reverse)

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "bumble-strings": "0.4.1",
     "d3": "3.5.6",
     "git-log-utils": "0.2.3",
-    "moment": "2.10.6",
+    "moment": "2.20.1",
     "underscore-plus": "1.x"
   },
   "package-deps": [

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "d3": "3.5.6",
     "git-log-utils": "0.2.3",
     "moment": "2.10.6",
-    "split-diff": "git://github.com/mupchrch/split-diff.git",
+    "split-diff": "https://github.com/mupchrch/split-diff/archive/v1.3.0.tar.gz",
     "underscore-plus": "1.x"
   },
   "devDependencies": {}

--- a/styles/git-time-machine.less
+++ b/styles/git-time-machine.less
@@ -32,9 +32,11 @@
   }
   
   .stats {
-    display: inline-block;
-    float: left;
-    margin-top: 3px;
+    margin-top: 5px;
+    /* margin-left: 5px; */
+    margin-bottom: 5px;
+    text-align: center;
+    font-size: 11px;  
   }
 
   .axis path,

--- a/styles/git-time-machine.less
+++ b/styles/git-time-machine.less
@@ -21,9 +21,11 @@
     height: 16px;
     cursor: pointer;
     z-index: 4;
-  }
-  .close-handle:hover {
-    color: @text-color-highlight;
+    color: @text-color-subtle;
+    
+    &:hover {
+      color: @text-color-highlight;
+    }
   }
 
   .stats {

--- a/styles/git-time-machine.less
+++ b/styles/git-time-machine.less
@@ -132,6 +132,25 @@
   }
 } // .git-timemachine-popup
 
+
+.select-list.popover-list.git-timemachine-revselector-popup {
+  position: absolute;
+  z-index: 10;
+  width: 350px;
+  background: @base-background-color;
+  color: @text-color;
+
+  .header {
+    width: 100%;
+    overflow: hidden;
+    > div {
+      display: inline-block;
+      width: 30%;
+      margin-right: 10px;
+    }
+  }
+}
+
 // this element is located appended inside the split diff UI control panel
 .timemachine-rev-select {
   &.left-rev {

--- a/styles/git-time-machine.less
+++ b/styles/git-time-machine.less
@@ -3,6 +3,7 @@
 // See https://github.com/atom/atom-dark-ui/blob/master/styles/ui-variables.less
 // for a full listing of what's available.
 @import "ui-variables";
+@import "syntax-variables";
 @import "../node_modules/split-diff/styles/split-diff.less";
 
 .git-time-machine {
@@ -62,13 +63,23 @@
       opacity: .3;
   }
 
-  .hover-marker {
+  .rev-marker(@backgroundColor) {
+    background-color: @backgroundColor;
     position: absolute;
     height: ~"calc(100% - 25px)";
     width: 5px;
     top: 0px;
-    right: 10px;
-    background-color: @pane-item-border-color;
+  }
+  .hover-marker {
+    .rev-marker(@pane-item-border-color);    
+  }
+
+  .left-rev-marker {
+    .rev-marker(fade(@syntax-color-removed, 80%););
+  }
+
+  .right-rev-marker {
+    .rev-marker(fade(@syntax-color-added, 80%););
   }
 
 }

--- a/styles/git-time-machine.less
+++ b/styles/git-time-machine.less
@@ -130,4 +130,16 @@
       }
     }
   }
+} // .git-timemachine-popup
+
+// this element is located appended inside the split diff UI control panel
+.timemachine-rev-select {
+  &.left-rev {
+    margin-right: 40px;
+  }
+  &.right-rev {
+    margin-left: 40px;
+  }
 }
+
+

--- a/styles/git-time-machine.less
+++ b/styles/git-time-machine.less
@@ -153,12 +153,9 @@
 
 // this element is located appended inside the split diff UI control panel
 .timemachine-rev-select {
-  &.left-rev {
-    margin-right: 40px;
-  }
-  &.right-rev {
-    margin-left: 40px;
-  }
+  display: inline-block;
+  // keeps the split-diff center buttons in the center when the rev label has diff lengths left and right
+  min-width: 200px;
 }
 
 

--- a/styles/git-time-machine.less
+++ b/styles/git-time-machine.less
@@ -91,7 +91,7 @@
     position: absolute;
     z-index: 10;
     width: 400px;
-    max-height: 300px;
+    max-height: 320px;
     overflow-y: auto;
     border: solid 4px @pane-item-border-color;
   }
@@ -99,6 +99,18 @@
   .controls {
     float: right;
   }
+  
+  .rev-scroller {
+    max-height: 240px;
+    overflow: scroll;
+    border-bottom: solid 1px @pane-item-border-color;
+  }
+  
+  .helper-text {
+    padding: 10px;
+  }
+  
+  
   ul {
     list-style-type: none;
   }

--- a/styles/git-time-machine.less
+++ b/styles/git-time-machine.less
@@ -167,4 +167,7 @@
   min-width: 200px;
 }
 
+.split-diff-ui .mid {
+  min-width: 600px;
+}
 


### PR DESCRIPTION
### Big changes for V2:

- Oldest rev should open to the left of newer rev because, as we all know, time travels from left to right :)

### New Features

- Ability to compare any two points in time.  **Click** on time plot or in hover popup to set the revision displayed in the left editor.  **Shift click** on the time plot or in the hover popup will set the right editor version.
- Ability to step back in time.   git-time-machine adds a revision display and selector to the split-diff control bar to allow you to step forward and backward 1 step at a time

### Plus a bunch of love 

Thank you to everyone who contributed to this release @mupchrch, @waldnzwrld, @chimit, @cbeninati, @Uzitech, @Alhadis, @apetro, @maskott, @DSpeckhals, @stevelacy, @melvinsh  