### PR TITLE
Move close panel button to left

### DIFF
--- a/styles/git-time-machine.less
+++ b/styles/git-time-machine.less
@@ -27,7 +27,7 @@
   .close-handle {
     position: absolute;
     top: 7px;
-    right: 16px;
+    left: 16px;
     width: 16px;
     height: 16px;
     cursor: pointer;


### PR DESCRIPTION
As stated in #138, 

> The most recent commits (the ones you are likely most interested in inspecting) appear on the right-side. The "close panel" button is also on the right side. I find myself unable to click on the most recent commits because the close panel button is in the way.

It seems reasonable to move the close button to the left.